### PR TITLE
Added failure handler for non-ready Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added failure handler for not-ready Pods test
+
 ## [0.2.1] - 2024-10-01
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 replace github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.4.2
 
 require (
-	github.com/giantswarm/clustertest v1.26.1
+	github.com/giantswarm/clustertest v1.27.2
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	sigs.k8s.io/controller-runtime v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/giantswarm/apiextensions-application v0.6.2 h1:XL86OrpprWl5Wp38EUvUXt3ztTo25+V63oDVlFwDpNg=
 github.com/giantswarm/apiextensions-application v0.6.2/go.mod h1:8ylqSmDSzFblCppRQTFo8v9s/F6MX6RTusVVoDDfWso=
-github.com/giantswarm/clustertest v1.26.1 h1:Mw87nZUD2J2sI6pOD9MiBgb7f6/SFK16zG6K3BIxMFA=
-github.com/giantswarm/clustertest v1.26.1/go.mod h1:G7plyfSfAlRINQD5V5X7mePZMYqjM6h1BxGZU/YRk/k=
+github.com/giantswarm/clustertest v1.27.2 h1:ji2Yzi/7bRu+gnihyEw7pNhuO6g1rr1LAsz9L6fApbA=
+github.com/giantswarm/clustertest v1.27.2/go.mod h1:G7plyfSfAlRINQD5V5X7mePZMYqjM6h1BxGZU/YRk/k=
 github.com/giantswarm/k8smetadata v0.25.0 h1:6mKmmm4xHPuBvxDMAkIhU5oj6KJkJSaR2s5esIsnHs4=
 github.com/giantswarm/k8smetadata v0.25.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubectl-gs/v2 v2.57.0 h1:IMmho55Qq+WE+frJXcTBhx19+J54xwu/j4+pGU5YecA=

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -109,9 +109,12 @@ func RunBasic() {
 					5,
 					time.Second,
 				)).
-				WithTimeout(5 * time.Minute).
+				WithTimeout(5*time.Minute).
 				WithPolling(wait.DefaultInterval).
-				Should(Succeed())
+				Should(
+					Succeed(),
+					failurehandler.PodsNotReady(state.GetFramework(), fakeWC),
+				)
 		})
 
 	})


### PR DESCRIPTION
### What this PR does

Gets more debug details when Pods are found to not be ready

### Checklist

- [ ] Update changelog in CHANGELOG.md.

### Trigger e2e tests

NOT CURRENTLY IMPLEMENTED
