### PR TITLE
Reduce consistent check for worker nodes down to 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced consistent check for worker nodes from 12 down to 3
+
 ## [0.5.0] - 2025-05-30
 
 ### Added

--- a/internal/common/basic.go
+++ b/internal/common/basic.go
@@ -91,7 +91,7 @@ func RunBasic() {
 					}
 					return nil
 				},
-				12, 5*time.Second)).
+				3, 5*time.Second)).
 				WithTimeout(15 * time.Minute).
 				WithPolling(wait.DefaultInterval).
 				Should(Succeed())


### PR DESCRIPTION
### What this PR does

No need to check 12 times for the worker nodes to be ready, this just reduces down to 3 consistent checks for all expected worker nodes being ready.

### Checklist

- [x] Update changelog in CHANGELOG.md.

### Trigger e2e tests

NOT CURRENTLY IMPLEMENTED
